### PR TITLE
[43기 신정호] ADD: 카카오 로그인 구현

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -18,6 +18,7 @@
 .env.development.local
 .env.test.local
 .env.production.local
+.env
 
 
 npm-debug.log*

--- a/package-lock.json
+++ b/package-lock.json
@@ -17,6 +17,7 @@
         "react-router-dom": "^6.9.0",
         "react-scripts": "5.0.1",
         "react-slick": "^0.29.0",
+        "react-spinners": "^0.13.8",
         "slick-carousel": "^1.8.1",
         "styled-components": "^5.3.9",
         "styled-reset": "^4.4.5",
@@ -6877,14 +6878,6 @@
       "dependencies": {
         "no-case": "^3.0.4",
         "tslib": "^2.0.3"
-      }
-    },
-    "node_modules/dotenv": {
-      "version": "10.0.0",
-      "resolved": "https://registry.npmjs.org/dotenv/-/dotenv-10.0.0.tgz",
-      "integrity": "sha512-rlBi9d8jpv9Sf1klPjNfFAuWDjKLwTIJJ/VxtoTwIR6hnZxcEOQCZg2oIL3MWBYw5GpUDKOEnND7LXTbIpQ03Q==",
-      "engines": {
-        "node": ">=10"
       }
     },
     "node_modules/dotenv-expand": {
@@ -14671,6 +14664,14 @@
         }
       }
     },
+    "node_modules/react-scripts/node_modules/dotenv": {
+      "version": "10.0.0",
+      "resolved": "https://registry.npmjs.org/dotenv/-/dotenv-10.0.0.tgz",
+      "integrity": "sha512-rlBi9d8jpv9Sf1klPjNfFAuWDjKLwTIJJ/VxtoTwIR6hnZxcEOQCZg2oIL3MWBYw5GpUDKOEnND7LXTbIpQ03Q==",
+      "engines": {
+        "node": ">=10"
+      }
+    },
     "node_modules/react-slick": {
       "version": "0.29.0",
       "resolved": "https://registry.npmjs.org/react-slick/-/react-slick-0.29.0.tgz",
@@ -14685,6 +14686,15 @@
       "peerDependencies": {
         "react": "^0.14.0 || ^15.0.1 || ^16.0.0 || ^17.0.0 || ^18.0.0",
         "react-dom": "^0.14.0 || ^15.0.1 || ^16.0.0 || ^17.0.0 || ^18.0.0"
+      }
+    },
+    "node_modules/react-spinners": {
+      "version": "0.13.8",
+      "resolved": "https://registry.npmjs.org/react-spinners/-/react-spinners-0.13.8.tgz",
+      "integrity": "sha512-3e+k56lUkPj0vb5NDXPVFAOkPC//XyhKPJjvcGjyMNPWsBKpplfeyialP74G7H7+It7KzhtET+MvGqbKgAqpZA==",
+      "peerDependencies": {
+        "react": "^16.0.0 || ^17.0.0 || ^18.0.0",
+        "react-dom": "^16.0.0 || ^17.0.0 || ^18.0.0"
       }
     },
     "node_modules/read-cache": {

--- a/package.json
+++ b/package.json
@@ -12,6 +12,7 @@
     "react-router-dom": "^6.9.0",
     "react-scripts": "5.0.1",
     "react-slick": "^0.29.0",
+    "react-spinners": "^0.13.8",
     "slick-carousel": "^1.8.1",
     "styled-components": "^5.3.9",
     "styled-reset": "^4.4.5",

--- a/src/Router.js
+++ b/src/Router.js
@@ -9,6 +9,7 @@ import Order from './pages/Order/Order';
 import ProductDetail from './pages/ProductDetail/ProductDetail';
 import ShoppingList from './pages/ShoppingList/ShoppingList';
 import HomepartyList from './pages/HomepartyList/HomepartyList';
+import Redirect from './pages/SignIn/Redirect';
 
 import ProductList from './pages/ProductList/ProductList';
 const Router = () => {
@@ -23,6 +24,7 @@ const Router = () => {
         <Route path="/productdetail/:id" element={<ProductDetail />} />
         <Route path="/homepartylist" element={<HomepartyList />} />
         <Route path="/productlist" element={<ProductList />} />
+        <Route path="auth/kakao/callback" element={<Redirect />} />
       </Routes>
       <Footer />
     </BrowserRouter>

--- a/src/components/Spinner/Spinner.js
+++ b/src/components/Spinner/Spinner.js
@@ -1,0 +1,13 @@
+import React from 'react';
+import { PacmanLoader } from 'react-spinners';
+import * as S from './SpinnerStyle';
+
+const Spinner = () => {
+  return (
+    <S.Wrap>
+      <PacmanLoader color="#568a35" />
+    </S.Wrap>
+  );
+};
+
+export default Spinner;

--- a/src/components/Spinner/SpinnerStyle.js
+++ b/src/components/Spinner/SpinnerStyle.js
@@ -1,0 +1,10 @@
+import styled from 'styled-components';
+
+export const Wrap = styled.div`
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  width: 100%;
+  margin-top: 50px;
+  min-height: 380px;
+`;

--- a/src/config.js
+++ b/src/config.js
@@ -1,0 +1,9 @@
+export const BASE_URL = 'http://10.58.52.209:3000';
+export const KAKAO_BASE_URL = 'https://kauth.kakao.com';
+export const REDIRECT_URI = 'http://localhost:3000/auth/kakao/callback';
+
+export const API = {
+  auth: `${KAKAO_BASE_URL}/oauth/authorize?client_`,
+  getToken: `${KAKAO_BASE_URL}/oauth/token?grant_type=authorization_code&client_`,
+  redirect: `${BASE_URL}/users/kakao/login`,
+};

--- a/src/pages/Signin/Oauth.js
+++ b/src/pages/Signin/Oauth.js
@@ -1,0 +1,5 @@
+import { API, REDIRECT_URI } from '../../config';
+
+export const REST_API_KEY = process.env.REACT_APP_REST_API_KEY;
+
+export const KAKAO_AUTH_URL = `${API.auth}id=${REST_API_KEY}&redirect_uri=${REDIRECT_URI}&response_type=code`;

--- a/src/pages/Signin/Redirect.js
+++ b/src/pages/Signin/Redirect.js
@@ -1,0 +1,43 @@
+import React, { useEffect } from 'react';
+import { useNavigate, useSearchParams } from 'react-router-dom';
+import { REST_API_KEY } from './Oauth';
+import { API, REDIRECT_URI } from '../../config';
+import Spinner from '../../components/Spinner/Spinner';
+
+const Redirect = () => {
+  const [searchParams, setSearchParams] = useSearchParams();
+  const navigate = useNavigate();
+  const code = searchParams.get('code');
+
+  useEffect(() => {
+    fetch(
+      `${API.getToken}id=${REST_API_KEY}&redirect_uri=${REDIRECT_URI}&code=${code}`,
+      {
+        method: 'POST',
+        headers: {
+          'Content-Type': 'application/x-www-form-urlencoded;',
+        },
+      }
+    )
+      .then(res => res.json())
+      .then(data => {
+        fetch(`${API.redirect}`, {
+          method: 'POST',
+          headers: {
+            authorization: data.access_token,
+          },
+        })
+          .then(res => res.json())
+          .then(data => {
+            if (data) {
+              localStorage.setItem('token', data.access_token);
+              navigate('/');
+            }
+          });
+      });
+  }, []);
+
+  return <Spinner />;
+};
+
+export default Redirect;

--- a/src/pages/Signin/Signin.js
+++ b/src/pages/Signin/Signin.js
@@ -1,15 +1,20 @@
 import React from 'react';
+import { KAKAO_AUTH_URL } from './Oauth';
 import { Width } from '../../styles/common';
 import * as S from './SignInStyle.js';
 
 const Signin = () => {
+  const kakaologin = () => {
+    window.location.href = KAKAO_AUTH_URL;
+  };
+
   return (
     <Width>
       <S.FlexCenter>
         <S.Container className="container">
           <S.Logo src="/images/logo/CBH2.png" />
           <S.Text>포근한 나의 집으로,</S.Text>
-          <S.KakaoLogin src="/images/kakao_login.png" />
+          <S.KakaoLogin src="/images/kakao_login.png" onClick={kakaologin} />
         </S.Container>
       </S.FlexCenter>
     </Width>


### PR DESCRIPTION
## :: 최근 작업 주제 (하나 이상의 주제를 선택해주세요.)
- [o] 기능 추가
- [ ] 리뷰 반영
- [ ] 리팩토링
- [ ] 버그 수정
- [ ] 컨벤션 수정

<br />

## :: 구현 목표 (해당 브랜치에서 구현하고자 하는 하나의 목표를 설정합니다.)
- 카카오 서버로 부터 토큰을 받아와서 백엔드에 전달하여 백엔드에서 만든 토큰,닉네임,프로필사진을 로컬 스토리지에 저장

<br />

## :: 구현 사항 설명 (작업한 내용을 상세하게 기록합니다.)
1. 로그인 페이지에서 카카오톡 로그인 버튼을 누른다.
2. 카카오톡 로그인 페이지로 페이지가 이동하고 로그인에 성공하면 
    경로가 auth/kakao/callback인 페이지로 이동하면서 파라미터에 인가코드를 준다. 
4. 파라미터에 있는 인가코드를 가져온 뒤 fetch를 통해 카카오톡에 토큰을 발급받고 발급받은 토큰을 백엔드 서버에 보내 
    jwt 토큰을 다시 수령하여 로컬 스토리지에 저장 후 메인페이지로 이동시켜준다.
5. 통신하는 동안 스피너가 나와서 사용자를 심심하지 않게 해준다.
<br />

## :: 성장 포인트 (해당 기능을 구현하며 고민했던 사항이나 새로 알게된 부분, 어려웠던 점 등을 작성합니다.)
- 카카오 API 사용법에 대한 이해도가 조금 올라간거같습니다.

<br />

